### PR TITLE
feat(api): add admin endpoint for triggering evaluation

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -6,6 +6,12 @@ info:
   description: |
     AR.IO ArNS Resolver
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: apiToken
+      description: ADMIN_API_KEY set in your .env file.
   schemas:
     ArweaveAddress:
       type: string
@@ -67,6 +73,57 @@ paths:
             application/json:
               schema:
                 '$ref': '#/components/schemas/Info'
+  '/ar-io/resolver/admin/evaluate':
+    post:
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              schema:
+                    type: object
+                    properties:
+                      message: { type: string }
+                      processId: { $ref: '#/components/schemas/ArweaveId' }
+        '202':
+          description: |-
+            202 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+        '400':
+          description: |-
+            400 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+        '401':
+          description: |-
+            401 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+        '500':
+          description: |-
+            500 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
   '/ar-io/resolver/records/{name}':
     head:
       parameters:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -96,15 +96,6 @@ paths:
                 type: object
                 properties:
                   message: { type: string }
-        '400':
-          description: |-
-            400 response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message: { type: string }
         '401':
           description: |-
             401 response

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -84,10 +84,9 @@ paths:
           content:
             application/json:
               schema:
-                    type: object
-                    properties:
-                      message: { type: string }
-                      processId: { $ref: '#/components/schemas/ArweaveId' }
+                type: object
+                properties:
+                  message: { type: string }
         '202':
           description: |-
             202 response

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,8 @@ import * as env from './lib/env.js';
 
 dotenv.config();
 
+export const ADMIN_API_KEY = env.varOrRandom('ADMIN_API_KEY');
+
 export const EVALUATION_INTERVAL_MS = +env.varOrDefault(
   'EVALUATION_INTERVAL_MS',
   `${1000 * 60 * 15}`, // 15 mins by default

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,26 +15,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import crypto from 'node:crypto';
+import { NextFunction, Request, Response } from 'express';
 
-import log from '../log.js';
+import * as config from './config.js';
 
-export function varOrDefault(envVarName: string, defaultValue: string): string {
-  const value = process.env[envVarName];
-  return value !== undefined && value.trim() !== '' ? value : defaultValue;
-}
-
-export function varOrUndefined(envVarName: string): string | undefined {
-  const value = process.env[envVarName];
-  return value !== undefined && value.trim() !== '' ? value : undefined;
-}
-
-export function varOrRandom(envVarName: string): string {
-  const value = process.env[envVarName];
-  if (value === undefined) {
-    const value = crypto.randomBytes(32).toString('base64url');
-    log.info(`${envVarName} not provided, generated random value: ${value}`);
-    return value;
+export const adminMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (req.headers['authorization'] !== `Bearer ${config.ADMIN_API_KEY}`) {
+    res.status(401).send({
+      message: 'Unauthorized',
+    });
+    return;
   }
-  return value;
-}
+  next();
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,7 +105,6 @@ app.post('/ar-io/resolver/admin/evaluate', adminMiddleware, (_req, res) => {
     evaluateArNSNames(); // don't await
     res.status(200).send({
       message: 'Evaluation triggered',
-      processId: config.IO_PROCESS_ID,
     });
   }
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,7 +40,7 @@ export const app = express();
 app.use(
   cors({
     origin: '*',
-    methods: ['GET', 'HEAD'],
+    methods: ['GET', 'HEAD', 'POST'],
   }),
 );
 

--- a/src/system.ts
+++ b/src/system.ts
@@ -185,8 +185,9 @@ export async function evaluateArNSNames() {
     );
     log.info('Finished evaluating arns names', {
       durationMs: Date.now() - startTime,
-      apexRecordCount: validArNSRecords.length,
+      apexRecordCount: Object.keys(apexRecords).length,
       evaluatedRecordCount: successfulEvaluationCount,
+      evaluatedProcessCount: Object.keys(processRecordMap).length,
       failedProcessCount:
         processIds.size - Object.keys(processRecordMap).length,
     });

--- a/src/system.ts
+++ b/src/system.ts
@@ -129,7 +129,6 @@ export async function evaluateArNSNames() {
       ([_, record]) => record.processId in processRecordMap,
     );
 
-    let totalRecordCount = 0;
     let successfulEvaluationCount = 0;
 
     const insertPromises = [];
@@ -176,7 +175,6 @@ export async function evaluateArNSNames() {
             });
           });
         insertPromises.push(promise);
-        totalRecordCount++;
       }
     }
     // use pLimit to prevent overwhelming cache

--- a/src/system.ts
+++ b/src/system.ts
@@ -33,6 +33,7 @@ import { ArNSResolvedData } from './types.js';
 let lastEvaluationTimestamp: number | undefined;
 let evaluationInProgress = false;
 export const getLastEvaluatedTimestamp = () => lastEvaluationTimestamp;
+export const isEvaluationInProgress = () => evaluationInProgress;
 export const contract: AoIORead = IO.init({
   processId: config.IO_PROCESS_ID,
 });
@@ -179,6 +180,7 @@ export async function evaluateArNSNames() {
     );
     log.info('Successfully evaluated arns names', {
       durationMs: Date.now() - startTime,
+      recordCount: validArNSRecords.length,
     });
     lastEvaluationTimestamp = Date.now();
   } catch (err: any) {


### PR DESCRIPTION
This allows operators to re-evaluate ad-hoc, assuming an existing evalution is not in progress. There is oppurtunity to support data in the post request if we want to retrigger the evaluation for a specific name vs. all of them.

### Evaluation Requests:
```bash
❯ curl -X POST -iL localhost:5001/ar-io/resolver/admin/evaluate
HTTP/1.1 401 Unauthorized
X-Powered-By: Express
Access-Control-Allow-Origin: *
Content-Security-Policy: default-src 'none'
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=utf-8
Content-Length: 576
Date: Thu, 27 Jun 2024 18:45:21 GMT
Connection: keep-alive
Keep-Alive: timeout=5

❯ curl -X POST localhost:5001/ar-io/resolver/admin/evaluate -H 'Authorization: Bearer VeejnPR_UmEbxzwpTDzPUJW54uVW3BSsvtOQ6qnqhEs'
{"message":"Unauthorized"}%    

❯ curl -X POST localhost:5001/ar-io/resolver/admin/evaluate -H 'Authorization: Bearer Nrat-atrMV1YqPHohP6VB3h0nd6rX5VMmnEa1fH2yEw'
{"message":"Evaluation in progress"}%                                                                                                                                                                

❯ curl -X POST localhost:5001/ar-io/resolver/admin/evaluate -H 'Authorization: Bearer Nrat-atrMV1YqPHohP6VB3h0nd6rX5VMmnEa1fH2yEw'
{"message":"Evaluation triggered" }%    
```

### Evaluation logs:
```bash
info: ADMIN_API_KEY not provided, generated random value: Vbjpo_mEJoznobxc8cXKMQ6FR0Se9BRm77TFmLM7gN8 {"timestamp":"2024-06-27T19:13:30.566Z"}
info: Evaluating arns names against ArNS registry {"processId":"agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA","timestamp":"2024-06-27T19:13:31.489Z"}
info: Listening on port 5001 {"timestamp":"2024-06-27T19:13:31.497Z"}
info: Retrieved apex records: {"count":1690,"timestamp":"2024-06-27T19:13:32.538Z"}
info: Retrieved unique process ids assigned to records: {"apexRecordCount":1690,"processCount":1644,"timestamp":"2024-06-27T19:14:28.055Z"}
info: Finished evaluating arns names {"apexRecordCount":1690,"durationMs":56688,"evaluatedProcessCount":1644,"evaluatedRecordCount":2108,"failedProcessCount":0,"timestamp":"2024-06-27T19:14:28.177Z"}
```